### PR TITLE
Use Discord relative timestamps for timer message

### DIFF
--- a/services/setup.js
+++ b/services/setup.js
@@ -7,9 +7,7 @@ const { I18N, t, langOf } = require('../i18n');
 const { getNextDrogonTime, getNextPeddlerTime, getDailyResetTime, getWeeklyResetTime, getNextBeastTime, getNextLimitedDealTime } = require('./timers');
 
 async function buildTimerBody(settings) {
-  const { formatCountdown, nowInTZ } = require('../utils/time');
   const tz = tzOf(settings);
-  const now        = nowInTZ(tz);
   const nextDrogon = getNextDrogonTime(tz);
   const nextPeddler= getNextPeddlerTime(tz);
   const nextDaily  = getDailyResetTime();
@@ -17,13 +15,15 @@ async function buildTimerBody(settings) {
   const nextBeast  = getNextBeastTime();
   const nextLimitedDeal = getNextLimitedDealTime(tz);
 
+  const toRelative = (date) => `<t:${Math.floor(date.getTime() / 1000)}:R>`;
+
   const lines = [
-    `⏰ **Daily Reset**: ${formatCountdown(nextDaily - now)}`,
-    `🔥 **Drogon**: ${formatCountdown(nextDrogon - now)}`,
-    `📅 **Weekly Reset**: ${formatCountdown(nextWeekly - now)}`,
-    `🔔 **Peddler**: ${formatCountdown(nextPeddler - now)}`,
-    `🐺 **Beast**: ${formatCountdown(nextBeast - now)}`,
-    `🛍️ **Limited Time Deal**: ${formatCountdown(nextLimitedDeal - now)}`
+    `⏰ **Daily Reset**: ${toRelative(nextDaily)}`,
+    `🔥 **Drogon**: ${toRelative(nextDrogon)}`,
+    `📅 **Weekly Reset**: ${toRelative(nextWeekly)}`,
+    `🔔 **Peddler**: ${toRelative(nextPeddler)}`,
+    `🐺 **Beast**: ${toRelative(nextBeast)}`,
+    `🛍️ **Limited Time Deal**: ${toRelative(nextLimitedDeal)}`
   ];
 
   if (styleOf(settings) === 'embed') {


### PR DESCRIPTION
## Summary
- replace the static countdown strings in the timer message with Discord-relative timestamps so the values auto-refresh in clients
- keep both compact and embed timer styles aligned on the new relative timestamp output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbca2cf67c832e9b5c2adf597743ec